### PR TITLE
Fix: Prevent empty state in Discord RPC activity

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -222,7 +222,8 @@ export default class ObsidianDiscordRPC extends Plugin {
         activity.state = "Working in a Vault";
       } else {
         activity.details = details;
-        activity.state = `${(await parsedText).toString()}`;
+        const calculatedState = await parsedText;
+        activity.state = calculatedState || `Vault: ${vault}`;
       }
 
       // if (this.settings.privacyMode) {


### PR DESCRIPTION
## Summary by Sourcery

Prevent empty state in Discord RPC activity by ensuring a default state is set when no specific details are available

Bug Fixes:
- Fixed an issue where Discord RPC activity could potentially have an empty state, which might cause display problems

Enhancements:
- Improved fallback logic for setting Discord RPC activity state
- Added more robust handling of activity state generation